### PR TITLE
Document ServerApi class from PHPC-1716

### DIFF
--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -905,6 +905,16 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
           </entry>
          </row>
          <row>
+          <entry>serverApi</entry>
+          <entry><classname>MongoDB\Driver\ServerApi</classname></entry>
+          <entry>
+           <para>
+            This option is used to declare a server API version for the manager.
+            If omitted, no API version is declared.
+           </para>
+          </entry>
+         </row>
+         <row>
           <entry>weak_cert_validation</entry>
           <entry><type>bool</type></entry>
           <entry>

--- a/reference/mongodb/mongodb/driver/serverapi.xml
+++ b/reference/mongodb/mongodb/driver/serverapi.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<phpdoc:classref xml:id="class.mongodb-driver-serverapi" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
+
+ <title>The MongoDB\Driver\ServerApi class</title>
+ <titleabbrev>MongoDB\Driver\ServerApi</titleabbrev>
+
+ <partintro>
+
+<!-- {{{ MongoDB\Driver\ServerApi intro -->
+  <section xml:id="mongodb-driver-serverapi.intro">
+   &reftitle.intro;
+   <para>
+
+   </para>
+  </section>
+<!-- }}} -->
+
+  <section xml:id="mongodb-driver-serverapi.synopsis">
+   &reftitle.classsynopsis;
+
+<!-- {{{ Synopsis -->
+   <classsynopsis>
+    <ooclass><classname>MongoDB\Driver\ServerApi</classname></ooclass>
+
+<!-- {{{ Class synopsis -->
+    <classsynopsisinfo>
+     <modifier>final</modifier>
+     <ooclass>
+      <classname>MongoDB\Driver\ServerApi</classname>
+     </ooclass>
+    </classsynopsisinfo>
+<!-- }}} -->
+    <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
+    <fieldsynopsis>
+     <modifier>const</modifier>
+     <type>string</type>
+     <varname linkend="mongodb-driver-serverapi.constants.v1">MongoDB\Driver\ServerAPI::V1</varname>
+     <initializer>1</initializer>
+    </fieldsynopsis>
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-serverapi')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+   </classsynopsis>
+<!-- }}} -->
+
+  </section>
+
+<!-- {{{ MongoDB\Driver\ServerApi constants -->
+  <section xml:id="mongodb-driver-serverapi.constants">
+   &reftitle.constants;
+   <variablelist>
+
+    <varlistentry xml:id="mongodb-driver-serverapi.constants.v1">
+     <term><constant>MongoDB\Driver\ServerApi::V1</constant></term>
+     <listitem>
+      <para>Server API version 1.</para>
+     </listitem>
+    </varlistentry>
+
+   </variablelist>
+  </section>
+<!-- }}} -->
+
+
+ </partintro>
+
+ <section xml:id="mongodb-driver-serverapi.examples">
+  &reftitle.examples;
+
+  <example>
+   <title>Declare an API version on a manager</title>
+   <programlisting role="php">
+    <![CDATA[
+<?php
+
+use MongoDB\Driver\Manager;
+use MongoDB\Driver\ServerApi;
+
+$v1 = new ServerApi(ServerApi::v1);
+$manager = new Manager('mongodb://localhost:27017', [], ['serverApi' => $v1]);
+
+$command = new MongoDB\Driver\Command(['buildInfo' => 1]);
+
+try {
+    $cursor = $manager->executeCommand('admin', $command);
+} catch(MongoDB\Driver\Exception $e) {
+    echo $e->getMessage(), "\n";
+    exit;
+}
+
+/* The buildInfo command returns a single result document, so we need to access
+ * the first result in the cursor. */
+$buildInfo = $cursor->toArray()[0];
+
+echo $buildInfo->version, "\n";
+
+?>
+]]>
+   </programlisting>
+
+   &example.outputs;
+   <screen>
+    <![CDATA[
+4.9.0-alpha7-49-gb968ca0
+]]>
+   </screen>
+  </example>
+
+  <example>
+   <title>Declare a strict API version on a manager</title>
+   <para>
+    The following example sets the <parameter>strict</parameter> flag, which
+    tells the server to reject any command that is not part of the declared API
+    version. This results in an error when running the buildInfo command.
+   </para>
+   <programlisting role="php">
+    <![CDATA[
+<?php
+
+use MongoDB\Driver\Manager;
+use MongoDB\Driver\ServerApi;
+
+$v1 = new ServerApi(ServerApi::v1, true);
+$manager = new Manager('mongodb://localhost:27017', [], ['serverApi' => $v1]);
+
+$command = new MongoDB\Driver\Command(['buildInfo' => 1]);
+
+try {
+    $cursor = $manager->executeCommand('admin', $command);
+} catch(MongoDB\Driver\Exception $e) {
+    echo $e->getMessage(), "\n";
+    exit;
+}
+
+/* The buildInfo command returns a single result document, so we need to access
+ * the first result in the cursor. */
+$buildInfo = $cursor->toArray()[0];
+
+echo $buildInfo->version, "\n";
+
+?>
+]]>
+   </programlisting>
+
+   &example.outputs;
+   <screen>
+    <![CDATA[
+Provided apiStrict:true, but the command buildInfo is not in API Version 1
+]]>
+   </screen>
+  </example>
+ </section>
+
+ &reference.mongodb.mongodb.driver.entities.serverapi;
+
+</phpdoc:classref>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/serverapi.xml
+++ b/reference/mongodb/mongodb/driver/serverapi.xml
@@ -30,6 +30,13 @@
      <ooclass>
       <classname>MongoDB\Driver\ServerApi</classname>
      </ooclass>
+     <oointerface>
+      <interfacename>MongoDB\BSON\Serializable</interfacename>
+     </oointerface>
+
+     <oointerface>
+      <interfacename>Serializable</interfacename>
+     </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
     <classsynopsisinfo role="comment">Constants</classsynopsisinfo>
@@ -37,7 +44,7 @@
      <modifier>const</modifier>
      <type>string</type>
      <varname linkend="mongodb-driver-serverapi.constants.v1">MongoDB\Driver\ServerAPI::V1</varname>
-     <initializer>1</initializer>
+     <initializer>"1"</initializer>
     </fieldsynopsis>
 
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>

--- a/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="mongodb-driver-serverApi.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ServerApi::bsonSerialize</refname>
+  <refpurpose>Returns an object for BSON serialization</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ServerApi::bsonSerialize</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns an object for serializing the ServerApi as BSON.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/serverapi/construct.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/construct.xml
@@ -17,7 +17,7 @@
   </methodsynopsis>
 
   <para>
-   Creates a new <classname>MongoDB\Driver\ServerApi</classname> instace used to
+   Creates a new <classname>MongoDB\Driver\ServerApi</classname> instance used to
    declare an API version when creating a
    <classname>MongoDB\Driver\Manager</classname>.
   </para>

--- a/reference/mongodb/mongodb/driver/serverapi/construct.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/construct.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision$ -->
+
+<refentry xml:id="mongodb-driver-serverapi.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ServerApi::__construct</refname>
+  <refpurpose>Create a new ServerApi instance</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ServerApi::__construct</methodname>
+   <methodparam><type>string</type><parameter>version</parameter></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>strict</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type>bool</type><parameter>deprecationErrors</parameter><initializer>&null;</initializer></methodparam>
+  </methodsynopsis>
+
+  <para>
+   Creates a new <classname>MongoDB\Driver\ServerApi</classname> instace used to
+   declare an API version when creating a
+   <classname>MongoDB\Driver\Manager</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/serverapi/serialize.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/serialize.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision: 342988 $ -->
+
+<refentry xml:id="mongodb-driver-serverApi.serialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ServerApi::serialize</refname>
+  <refpurpose>Serialize a ServerApi</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>string</type><methodname>MongoDB\Driver\ServerApi::serialize</methodname>
+   <void />
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  &no.function.parameters;
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the serialized representation of the
+   <classname>MongoDB\Driver\ServerApi</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\ServerApi::unserialize</methodname></member>
+   <member><function>serialize</function></member>
+   <member><link linkend="language.oop5.serialization">Serializing Objects</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/mongodb/driver/serverapi/unserialize.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/unserialize.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- $Revision: 342988 $ -->
+
+<refentry xml:id="mongodb-driver-serverApi.unserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <refnamediv>
+  <refname>MongoDB\Driver\ServerApi::unserialize</refname>
+  <refpurpose>Unserialize a ServerApi</refpurpose>
+ </refnamediv>
+
+ <refsect1 role="description">
+  &reftitle.description;
+  <methodsynopsis>
+   <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\ServerApi::unserialize</methodname>
+   <methodparam><type>string</type><parameter>serialized</parameter></methodparam>
+  </methodsynopsis>
+ </refsect1>
+
+ <refsect1 role="parameters">
+  &reftitle.parameters;
+  <para>
+   <variablelist>
+    <varlistentry>
+     <term><parameter>serialized</parameter></term>
+     <listitem>
+      <para>
+       The serialized <classname>MongoDB\Driver\ServerApi</classname>.
+      </para>
+     </listitem>
+    </varlistentry>
+   </variablelist>
+  </para>
+ </refsect1>
+
+ <refsect1 role="returnvalues">
+  &reftitle.returnvalues;
+  <para>
+   Returns the unserialized <classname>MongoDB\Driver\ServerApi</classname>.
+  </para>
+ </refsect1>
+
+ <refsect1 role="errors">
+  &reftitle.errors;
+  <simplelist>
+   &mongodb.throws.argumentparsing;
+   <member>Throws <classname>MongoDB\Driver\Exception\UnexpectedValueException</classname> if the properties cannot be unserialized (i.e. <parameter>serialized</parameter> was malformed).</member>
+   <member>Throws <classname>MongoDB\Driver\Exception\InvalidArgumentException</classname> if the properties are invalid (e.g. missing fields or invalid values).</member>
+  </simplelist>
+ </refsect1>
+
+ <refsect1 role="seealso">
+  &reftitle.seealso;
+  <simplelist>
+   <member><methodname>MongoDB\Driver\ServerApi::serialize</methodname></member>
+    <member><function>unserialize</function></member>
+    <member><link linkend="language.oop5.serialization">Serializing Objects</link></member>
+  </simplelist>
+ </refsect1>
+
+</refentry>
+
+<!-- Keep this comment at the end of the file
+Local variables:
+mode: sgml
+sgml-omittag:t
+sgml-shorttag:t
+sgml-minimize-attributes:nil
+sgml-always-quote-attributes:t
+sgml-indent-step:1
+sgml-indent-data:t
+indent-tabs-mode:nil
+sgml-parent-document:nil
+sgml-default-dtd-file:"~/.phpdoc/manual.ced"
+sgml-exposed-tags:nil
+sgml-local-catalogs:nil
+sgml-local-ecat-files:nil
+End:
+vim600: syn=xml fen fdm=syntax fdl=2 si
+vim: et tw=78 syn=sgml
+vi: ts=1 sw=1
+-->

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -112,6 +112,9 @@
  <function name='mongodb\driver\server::isprimary' from='mongodb &gt;=1.0.0'/>
  <function name='mongodb\driver\server::issecondary' from='mongodb &gt;=1.0.0'/>
 
+ <function name='mongodb\driver\server' from='mongodb &gt;=1.10.0'/>
+ <function name='mongodb\driver\server::__construct' from='mongodb &gt;=1.10.0'/>
+
  <function name='mongodb\driver\session' from='mongodb &gt;=1.4.0'/>
  <function name='mongodb\driver\session::__construct' from='mongodb &gt;=1.4.0'/>
  <function name='mongodb\driver\session::aborttransaction' from='mongodb &gt;=1.5.0'/>


### PR DESCRIPTION
@jmikola: this is the documentation for the changes introduced in PHPC-1716. I decided to give an example in the class documentation instead of adding it to the manager constructor documentation.

I'll revisit this separately to figure out whether this PR should go to https://github.com/php/doc-en or if I should push to the PHP repo myself without a PR.