### PR TITLE
MongoDB: Document type changes in 1.15

### DIFF
--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -2694,7 +2694,7 @@ used.</para>'>
 
 <!-- mongodb -->
 <!ENTITY mongodb.changelog.tentative-return-types '
-       <row>
+       <row xmlns="http://docbook.org/ns/docbook">
         <entry>PECL mongodb 1.15.0</entry>
         <entry>
          Return types for methods are declared as tentative on PHP 8.0 and newer,

--- a/language-snippets.ent
+++ b/language-snippets.ent
@@ -1795,7 +1795,7 @@ this extension is still available within <acronym xmlns="http://docbook.org/ns/d
 <link xmlns="http://docbook.org/ns/docbook" linkend="install.windows.building">building on Windows</link>
 section.'>
 
-<!ENTITY pecl.windows.download.avail 'Windows binaries (<acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> files) 
+<!ENTITY pecl.windows.download.avail 'Windows binaries (<acronym xmlns="http://docbook.org/ns/docbook">DLL</acronym> files)
 for this <acronym xmlns="http://docbook.org/ns/docbook">PECL</acronym> extension are available from the PECL website.'>
 
 <!ENTITY pecl.windows.download.unbundled '&pecl.windows.download;'>
@@ -1948,7 +1948,7 @@ the number will be returned as a &string;.</para></note>'>
 <title>Security warning: SQL injection</title><para>If the query contains any variable
 input then <link linkend="mysqli.quickstart.prepared-statements">parameterized
 prepared statements</link> should be used instead. Alternatively, the
-data must be properly formatted and all strings must be escaped using 
+data must be properly formatted and all strings must be escaped using
 the <function>mysqli_real_escape_string</function>
 function.</para></warning>'>
 
@@ -2088,11 +2088,11 @@ See also the <link linkend="mysqlinfo.api.choosing">MySQL: choosing an API</link
 Alternatives to this function include:</para>'>
 
 <!ENTITY mysql.close.connections.result.sets '<para xmlns="http://docbook.org/ns/docbook">
-Open non-persistent MySQL connections and result sets are automatically destroyed when a 
-PHP script finishes its execution. So, while explicitly closing open 
-connections and freeing result sets is optional, doing so is recommended. 
-This will immediately return resources to PHP and MySQL, which can 
-improve performance. For related information, see 
+Open non-persistent MySQL connections and result sets are automatically destroyed when a
+PHP script finishes its execution. So, while explicitly closing open
+connections and freeing result sets is optional, doing so is recommended.
+This will immediately return resources to PHP and MySQL, which can
+improve performance. For related information, see
 <link linkend="language.types.resource.self-destruct">freeing resources</link></para>'>
 
 <!-- Sybase Notes -->
@@ -2662,9 +2662,9 @@ paths</simpara></warning>
 <!ENTITY mongo.gridfs.store.return '<para xmlns="http://docbook.org/ns/docbook">Returns the <literal>_id</literal> of the saved file document. This will be a generated <classname>MongoId</classname> unless an <literal>_id</literal> was explicitly specified in the <parameter>metadata</parameter> parameter.</para>'>
 <!ENTITY mongo.mongowritebatch.writeoptions.description '<listitem xmlns="http://docbook.org/ns/docbook"><para>An array of Write Options.<informaltable><thead><row><entry>key</entry><entry>value meaning</entry></row></thead><tbody><row><entry>w (int|string)</entry><entry><link linkend="mongo.writeconcerns">Write concern</link> value</entry></row><row><entry>wtimeout (int)</entry><entry><link linkend="mongo.writeconcerns">Maximum time to wait for replication</link></entry></row><row><entry>ordered</entry><entry>Determines if MongoDB must apply this batch in order. Ordered writes execute serially (i.e. one at a time) and execution will stop after the first error. Unordered writes may execute in parallel and execution will not stop after the first error. Defaults to &true;</entry></row><row><entry>j (bool)</entry><entry>Wait for journaling on the primary. This value is discouraged, use WriteConcern instead</entry></row><row><entry>fsync (bool)</entry><entry>Wait for fsync on the primary. This value is discouraged, use WriteConcern instead</entry></row></tbody></informaltable></para></listitem>'>
 <!ENTITY mongo.mongowritebatch.collection.description '<listitem xmlns="http://docbook.org/ns/docbook"><para>The <classname>MongoCollection</classname> to execute the batch on. Its <link linkend="mongo.writeconcerns">write concern</link> will be copied and used as the default write concern if none is given as <parameter>$write_options</parameter> or during <methodname>MongoWriteBatch::execute</methodname>.</para></listitem>'>
-<!ENTITY mongo.context.server ' <varlistentry xmlns="http://docbook.org/ns/docbook"> <term> <parameter>server</parameter> </term> <listitem> <para> An array containing the basic information about the server that was picked. <informaltable> <tgroup cols="2"> <thead> <row> <entry>key</entry> <entry>value</entry> </row> </thead> <tbody> <row> <entry>hash</entry> <entry>server hash, example: <literal>localhost:27017;-;X;56052</literal></entry> </row> <row> <entry>type</entry> <entry>Node type (primary/secondary/mongos/arbiter): <literal>2</literal></entry> </row> <row> <entry>max_bson_size</entry> <entry>The maximum BSON Size over the wire this node accepts: <literal>16777216</literal></entry> </row> <row> <entry>max_message_size</entry> <entry>The maximum Message Size over the wire this node accepts: <literal>48000000</literal></entry> </row> <row> <entry>request_id</entry> <entry>The request identifier for this message: <literal>42</literal></entry> </row> </tbody> </tgroup> </informaltable> </para> </listitem> </varlistentry>'> 
-<!ENTITY mongo.context.writeoptions '<varlistentry xmlns="http://docbook.org/ns/docbook"> <term> <parameter>writeOptions</parameter> </term> <listitem> <para> <informaltable> <tgroup cols="2"> <thead> <row> <entry>key</entry> <entry>value</entry> </row> </thead> <tbody> <row> <entry>ordered</entry> <entry>boolean, if the operation (in case of batch operation) must be executed sequentually (ordered=true)</entry> </row> <row> <entry>writeConcern</entry> <entry>An array of writeConcern options (see below)</entry> </row> </tbody> </tgroup> </informaltable> <table> <title>writeConcern array values</title> <tgroup cols="2"> <thead> <row> <entry>key</entry> <entry>value</entry> </row> </thead> <tbody> <row> <entry>fsync</entry> <entry>boolean, force flushing to disk before returning</entry> </row> <row> <entry>j</entry> <entry>boolean, force journal write before returning</entry> </row> <row> <entry>wtimeout</entry> <entry>integer, milliseconds, maximum time the primary is allowed to wait to verify replication</entry> </row> <row> <entry>w</entry> <entry>integer=server count, or string=replication-tag</entry> </row> </tbody> </tgroup> </table> </para> </listitem> </varlistentry>'> 
-<!ENTITY mongo.context.protocoloptions ' <varlistentry xmlns="http://docbook.org/ns/docbook"> <term> <parameter>protocolOptions</parameter> </term> <listitem> <para> <informaltable> <tgroup cols="2"> <thead> <row> <entry>key</entry> <entry>value</entry> </row> </thead> <tbody> <row> <entry>message_length</entry> <entry>The total size (in bytes) of the encoded message being sent over the wire</entry> </row> <row> <entry>request_id</entry> <entry>The request identifier for this message: <literal>42</literal></entry> </row> <row> <entry>namespace</entry> <entry>The MongoDB namespace used for the protocol message <literal>dbname.collectionname</literal></entry> </row> </tbody> </tgroup> </informaltable> </para> </listitem> </varlistentry>'> 
+<!ENTITY mongo.context.server ' <varlistentry xmlns="http://docbook.org/ns/docbook"> <term> <parameter>server</parameter> </term> <listitem> <para> An array containing the basic information about the server that was picked. <informaltable> <tgroup cols="2"> <thead> <row> <entry>key</entry> <entry>value</entry> </row> </thead> <tbody> <row> <entry>hash</entry> <entry>server hash, example: <literal>localhost:27017;-;X;56052</literal></entry> </row> <row> <entry>type</entry> <entry>Node type (primary/secondary/mongos/arbiter): <literal>2</literal></entry> </row> <row> <entry>max_bson_size</entry> <entry>The maximum BSON Size over the wire this node accepts: <literal>16777216</literal></entry> </row> <row> <entry>max_message_size</entry> <entry>The maximum Message Size over the wire this node accepts: <literal>48000000</literal></entry> </row> <row> <entry>request_id</entry> <entry>The request identifier for this message: <literal>42</literal></entry> </row> </tbody> </tgroup> </informaltable> </para> </listitem> </varlistentry>'>
+<!ENTITY mongo.context.writeoptions '<varlistentry xmlns="http://docbook.org/ns/docbook"> <term> <parameter>writeOptions</parameter> </term> <listitem> <para> <informaltable> <tgroup cols="2"> <thead> <row> <entry>key</entry> <entry>value</entry> </row> </thead> <tbody> <row> <entry>ordered</entry> <entry>boolean, if the operation (in case of batch operation) must be executed sequentually (ordered=true)</entry> </row> <row> <entry>writeConcern</entry> <entry>An array of writeConcern options (see below)</entry> </row> </tbody> </tgroup> </informaltable> <table> <title>writeConcern array values</title> <tgroup cols="2"> <thead> <row> <entry>key</entry> <entry>value</entry> </row> </thead> <tbody> <row> <entry>fsync</entry> <entry>boolean, force flushing to disk before returning</entry> </row> <row> <entry>j</entry> <entry>boolean, force journal write before returning</entry> </row> <row> <entry>wtimeout</entry> <entry>integer, milliseconds, maximum time the primary is allowed to wait to verify replication</entry> </row> <row> <entry>w</entry> <entry>integer=server count, or string=replication-tag</entry> </row> </tbody> </tgroup> </table> </para> </listitem> </varlistentry>'>
+<!ENTITY mongo.context.protocoloptions ' <varlistentry xmlns="http://docbook.org/ns/docbook"> <term> <parameter>protocolOptions</parameter> </term> <listitem> <para> <informaltable> <tgroup cols="2"> <thead> <row> <entry>key</entry> <entry>value</entry> </row> </thead> <tbody> <row> <entry>message_length</entry> <entry>The total size (in bytes) of the encoded message being sent over the wire</entry> </row> <row> <entry>request_id</entry> <entry>The request identifier for this message: <literal>42</literal></entry> </row> <row> <entry>namespace</entry> <entry>The MongoDB namespace used for the protocol message <literal>dbname.collectionname</literal></entry> </row> </tbody> </tgroup> </informaltable> </para> </listitem> </varlistentry>'>
 <!ENTITY mongo.alternative.class.note '<para
 xmlns="http://docbook.org/ns/docbook">This extension that defines this class
 is deprecated. Instead, the <link linkend="set.mongodb">MongoDB</link> extension should be used.
@@ -2693,6 +2693,18 @@ the <link linkend="set.mongodb">MongoDB</link> extension should be
 used.</para>'>
 
 <!-- mongodb -->
+<!ENTITY mongodb.changelog.tentative-return-types '
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+'>
+
 <!ENTITY mongodb.option.collation '
          <row xmlns="http://docbook.org/ns/docbook">
           <entry>collation</entry>
@@ -3159,7 +3171,7 @@ local: {
     to specify which number argument to treat in the conversion.
    </para>
   </formalpara>
-  
+
   <para>
    <table>
     <title>Flags</title>
@@ -3633,7 +3645,7 @@ xmlns="http://docbook.org/ns/docbook"><simpara>This function has been
     with servers with valid SSL certificates, as distributors generally
     configure OpenSSL to use known good CA bundles.
    </para>
-   
+
    <para xmlns="http://docbook.org/ns/docbook">
     The default CA bundle may be overridden on a global basis by setting
     either the openssl.cafile or openssl.capath configuration setting, or on a

--- a/reference/mongodb/architecture.xml
+++ b/reference/mongodb/architecture.xml
@@ -441,21 +441,21 @@ class AnotherClass1 implements MongoDB\BSON\Serializable {
   public $foo = 42;
   protected $prot = "wine";
   private $fpr = "cheese";
-  function bsonSerialize() {
+  function bsonSerialize(): array {
       return [ 'foo' => $this->foo, 'prot' => $this->prot ];
   }
 } // => { "foo" : 42, "prot" : "wine" }
 
 class AnotherClass2 implements MongoDB\BSON\Serializable {
   public $foo = 42;
-  function bsonSerialize() {
+  function bsonSerialize(): self {
       return $this;
   }
 } // => MongoDB\Driver\Exception\UnexpectedValueException("bsonSerialize() did not return an array or stdClass")
 
 class AnotherClass3 implements MongoDB\BSON\Serializable {
   private $elements = [ 'foo', 'bar' ];
-  function bsonSerialize() {
+  function bsonSerialize(): array {
       return $this->elements;
   }
 } // => { "0" : "foo", "1" : "bar" }
@@ -463,11 +463,11 @@ class AnotherClass3 implements MongoDB\BSON\Serializable {
 class ContainerClass implements MongoDB\BSON\Serializable {
   public $things = AnotherClass4 implements MongoDB\BSON\Serializable {
     private $elements = [ 0 => 'foo', 2 => 'bar' ];
-    function bsonSerialize() {
+    function bsonSerialize(): array {
       return $this->elements;
     }
   }
-  function bsonSerialize() {
+  function bsonSerialize(): array {
       return [ 'things' => $this->things ];
   }
 } // => { "things" : { "0" : "foo", "2" : "bar" } }
@@ -475,11 +475,11 @@ class ContainerClass implements MongoDB\BSON\Serializable {
 class ContainerClass implements MongoDB\BSON\Serializable {
   public $things = AnotherClass5 implements MongoDB\BSON\Serializable {
     private $elements = [ 0 => 'foo', 2 => 'bar' ];
-    function bsonSerialize() {
+    function bsonSerialize(): array {
       return array_values($this->elements);
     }
   }
-  function bsonSerialize() {
+  function bsonSerialize(): array {
       return [ 'things' => $this->things ];
   }
 } // => { "things" : [ "foo", "bar" ] }
@@ -487,11 +487,11 @@ class ContainerClass implements MongoDB\BSON\Serializable {
 class ContainerClass implements MongoDB\BSON\Serializable {
   public $things = AnotherClass6 implements MongoDB\BSON\Serializable {
     private $elements = [ 'foo', 'bar' ];
-    function bsonSerialize() {
+    function bsonSerialize(): array {
       return (object) $this->elements;
     }
   }
-  function bsonSerialize() {
+  function bsonSerialize(): array {
       return [ 'things' => $this->things ];
   }
 } // => { "things" : { "0" : "foo", "1" : "bar" } }
@@ -500,7 +500,7 @@ class UpperClass implements MongoDB\BSON\Persistable {
   public $foo = 42;
   protected $prot = "wine";
   private $fpr = "cheese";
-  function bsonSerialize() {
+  function bsonSerialize(): array {
       return [ 'foo' => $this->foo, 'prot' => $this->prot ];
   }
 } // => { "foo" : 42, "prot" : "wine", "__pclass" : { "$type" : "80", "$binary" : "VXBwZXJDbGFzcw==" } }

--- a/reference/mongodb/bson/binaryinterface.xml
+++ b/reference/mongodb/bson/binaryinterface.xml
@@ -41,15 +41,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/bson/binaryinterface.xml
+++ b/reference/mongodb/bson/binaryinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-bson-binaryinterface" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -27,6 +27,33 @@
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-binaryinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/decimal128/construct.xml
+++ b/reference/mongodb/bson/decimal128/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-bson-decimal128.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\BSON\Decimal128::__construct</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>value</parameter></methodparam>
+   <methodparam><type>string</type><parameter>value</parameter></methodparam>
   </methodsynopsis>
   &mongodb.note.decimal128;
  </refsect1>

--- a/reference/mongodb/bson/decimal128interface.xml
+++ b/reference/mongodb/bson/decimal128interface.xml
@@ -41,15 +41,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/bson/decimal128interface.xml
+++ b/reference/mongodb/bson/decimal128interface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-bson-decimal128interface" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -28,6 +28,32 @@
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-decimal128interface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
+  </section>
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/javascript/construct.xml
+++ b/reference/mongodb/bson/javascript/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-bson-javascript.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\BSON\Javascript::__construct</methodname>
    <methodparam><type>string</type><parameter>code</parameter></methodparam>
-   <methodparam choice="opt"><type class="union"><type>array</type><type>object</type></type><parameter>scope</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>object</type><type>null</type></type><parameter>scope</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
  </refsect1>
 

--- a/reference/mongodb/bson/javascriptinterface.xml
+++ b/reference/mongodb/bson/javascriptinterface.xml
@@ -42,15 +42,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/bson/javascriptinterface.xml
+++ b/reference/mongodb/bson/javascriptinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-bson-javascriptinterface" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -28,6 +28,33 @@
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-javascriptinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/objectid/construct.xml
+++ b/reference/mongodb/bson/objectid/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-bson-objectid.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\BSON\ObjectId::__construct</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>id</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>id</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
  </refsect1>
 

--- a/reference/mongodb/bson/objectidinterface.xml
+++ b/reference/mongodb/bson/objectidinterface.xml
@@ -42,15 +42,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/bson/objectidinterface.xml
+++ b/reference/mongodb/bson/objectidinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-bson-objectidinterface" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -28,6 +28,33 @@
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-objectidinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/regexinterface.xml
+++ b/reference/mongodb/bson/regexinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-bson-regexinterface" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -27,6 +27,33 @@
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-regexinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/regexinterface.xml
+++ b/reference/mongodb/bson/regexinterface.xml
@@ -41,15 +41,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/bson/serializable.xml
+++ b/reference/mongodb/bson/serializable.xml
@@ -30,13 +30,13 @@
      <ooclass>
       <classname>MongoDB\BSON\Serializable</classname>
      </ooclass>
-     
+
      <oointerface>
       <interfacename>MongoDB\BSON\Type</interfacename>
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
@@ -44,6 +44,32 @@
 
   </section>
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
  </partintro>
 
  &reference.mongodb.bson.entities.serializable;

--- a/reference/mongodb/bson/serializable.xml
+++ b/reference/mongodb/bson/serializable.xml
@@ -56,15 +56,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/bson/serializable/bsonserialize.xml
+++ b/reference/mongodb/bson/serializable/bsonserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-bson-serializable.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -67,7 +67,7 @@ class MyDocument implements MongoDB\BSON\Serializable
         $this->id = new MongoDB\BSON\ObjectId;
     }
 
-    function bsonSerialize()
+    function bsonSerialize(): array
     {
         return ['_id' => $this->id, 'foo' => 'bar'];
     }
@@ -95,7 +95,7 @@ echo MongoDB\BSON\toJSON($bson), "\n";
 
 class MyArray implements MongoDB\BSON\Serializable
 {
-    function bsonSerialize()
+    function bsonSerialize(): array
     {
         return [1, 2, 3];
     }
@@ -123,7 +123,7 @@ echo MongoDB\BSON\toJSON($bson), "\n";
 
 class MyDocument implements MongoDB\BSON\Serializable
 {
-    function bsonSerialize()
+    function bsonSerialize(): array
     {
         return ['foo' => 'bar'];
     }
@@ -152,7 +152,7 @@ echo MongoDB\BSON\toJSON($bson), "\n";
 
 class MyArray implements MongoDB\BSON\Serializable
 {
-    function bsonSerialize()
+    function bsonSerialize(): array
     {
         return [1, 2, 3];
     }

--- a/reference/mongodb/bson/timestampinterface.xml
+++ b/reference/mongodb/bson/timestampinterface.xml
@@ -42,15 +42,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/bson/timestampinterface.xml
+++ b/reference/mongodb/bson/timestampinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-bson-timestampinterface" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -28,6 +28,33 @@
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-timestampinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
  </partintro>
 

--- a/reference/mongodb/bson/unserializable.xml
+++ b/reference/mongodb/bson/unserializable.xml
@@ -53,15 +53,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/bson/unserializable.xml
+++ b/reference/mongodb/bson/unserializable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-bson-unserializable" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -33,7 +33,7 @@
      </ooclass>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-unserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
@@ -41,6 +41,32 @@
 
   </section>
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
  </partintro>
 
  &reference.mongodb.bson.entities.unserializable;

--- a/reference/mongodb/bson/unserializable/bsonunserialize.xml
+++ b/reference/mongodb/bson/unserializable/bsonunserialize.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-bson-unserializable.bsonunserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -65,7 +65,7 @@ class MyDocument implements MongoDB\BSON\Unserializable
 {
     private $data = [];
 
-    function bsonUnserialize(array $data)
+    function bsonUnserialize(array $data): void
     {
         $this->data = $data;
     }

--- a/reference/mongodb/bson/utcdatetime/construct.xml
+++ b/reference/mongodb/bson/utcdatetime/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-bson-utcdatetime.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\BSON\UTCDateTime::__construct</methodname>
-   <methodparam choice="opt"><type class="union"><type>int</type><type>float</type><type>string</type><type>DateTimeInterface</type></type><parameter>milliseconds</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>float</type><type>string</type><type>DateTimeInterface</type><type>null</type></type><parameter>milliseconds</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
  </refsect1>
 
@@ -19,7 +19,7 @@
   &reftitle.parameters;
   <variablelist>
    <varlistentry>
-    <term><parameter>milliseconds</parameter> (<type class="union"><type>int</type><type>float</type><type>string</type><type>DateTimeInterface</type></type>)</term>
+    <term><parameter>milliseconds</parameter> (<type class="union"><type>int</type><type>float</type><type>string</type><type>DateTimeInterface</type><type>null</type></type>)</term>
     <listitem>
      <para>
       Number of milliseconds since the Unix epoch (Jan 1, 1970). Negative values

--- a/reference/mongodb/bson/utcdatetimeinterface.xml
+++ b/reference/mongodb/bson/utcdatetimeinterface.xml
@@ -42,15 +42,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/bson/utcdatetimeinterface.xml
+++ b/reference/mongodb/bson/utcdatetimeinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-bson-utcdatetimeinterface" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -28,6 +28,33 @@
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-utcdatetimeinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
  </partintro>
 

--- a/reference/mongodb/mongodb/driver/bulkwrite/construct.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-bulkwrite.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>public</modifier> <methodname>MongoDB\Driver\BulkWrite::__construct</methodname>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Constructs a new <classname>MongoDB\Driver\BulkWrite</classname>, which is a

--- a/reference/mongodb/mongodb/driver/bulkwrite/delete.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/delete.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-bulkwrite.delete" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\BulkWrite::delete</methodname>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>deleteOptions</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>deleteOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds a delete operation to the

--- a/reference/mongodb/mongodb/driver/bulkwrite/update.xml
+++ b/reference/mongodb/mongodb/driver/bulkwrite/update.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-bulkwrite.update" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\BulkWrite::update</methodname>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>newObj</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>updateOptions</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>updateOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Adds an update operation to the

--- a/reference/mongodb/mongodb/driver/clientencryption/createdatakey.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/createdatakey.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision: 344035 $ --> 
+<!-- $Revision: 344035 $ -->
 
 <refentry xml:id="mongodb-driver-clientencryption.createdatakey" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\ClientEncryption::createDataKey</refname>
   <refpurpose>Create a new encryption data key</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Binary</type><methodname>MongoDB\Driver\ClientEncryption::createDataKey</methodname>
    <methodparam><type>string</type><parameter>kmsProvider</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Creates a new key document and inserts it into the key vault collection.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
@@ -33,7 +33,7 @@
      </para>
     </listitem>
    </varlistentry>
-   
+
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>
@@ -235,7 +235,7 @@
    </informaltable>
   </para>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
+++ b/reference/mongodb/mongodb/driver/clientencryption/encrypt.xml
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision: 344035 $ --> 
+<!-- $Revision: 344035 $ -->
 
 <refentry xml:id="mongodb-driver-clientencryption.encrypt" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\ClientEncryption::encrypt</refname>
   <refpurpose>Encrypt a value</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\BSON\Binary</type><methodname>MongoDB\Driver\ClientEncryption::encrypt</methodname>
    <methodparam><type>mixed</type><parameter>value</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Encrypts the value.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
@@ -31,7 +31,7 @@
      </para>
     </listitem>
    </varlistentry>
-   
+
    <varlistentry>
     <term><parameter>options</parameter></term>
     <listitem>

--- a/reference/mongodb/mongodb/driver/command/construct.xml
+++ b/reference/mongodb/mongodb/driver/command/construct.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-command.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
   <refname>MongoDB\Driver\Command::__construct</refname>
   <refpurpose>Create a new Command</refpurpose>
  </refnamediv>
- 
+
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\Command::__construct</methodname>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>document</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>commandOptions</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>commandOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Constructs a new <classname>MongoDB\Driver\Command</classname>, which is an
@@ -28,7 +28,7 @@
    <classname>MongoDB\Driver\Cursor</classname>.
   </para>
  </refsect1>
- 
+
  <refsect1 role="parameters">
   &reftitle.parameters;
   <variablelist>
@@ -40,7 +40,7 @@
      </para>
     </listitem>
    </varlistentry>
-   
+
    <varlistentry>
     <term><parameter>commandOptions</parameter></term>
     <listitem>
@@ -85,14 +85,14 @@
    </varlistentry>
   </variablelist>
  </refsect1>
- 
+
  <refsect1 role="errors">
   &reftitle.errors;
   <simplelist>
    &mongodb.throws.argumentparsing;
   </simplelist>
  </refsect1>
- 
+
  <refsect1 role="changelog">
   &reftitle.changelog;
   <para>
@@ -119,7 +119,7 @@
    </informaltable>
   </para>
  </refsect1>
- 
+
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
@@ -188,7 +188,7 @@ array(13) {
 ]]>
    </screen>
   </example>
-  
+
   <example>
    <title><function>MongoDB\Driver\Command::__construct</function> example</title>
    <para>
@@ -228,8 +228,8 @@ var_dump($response);
    </screen>
   </example>
  </refsect1>
- 
- 
+
+
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
@@ -237,7 +237,7 @@ var_dump($response);
    <member><classname>MongoDB\Driver\Cursor</classname></member>
   </simplelist>
  </refsect1>
- 
+
 </refentry>
 
 <!-- Keep this comment at the end of the file

--- a/reference/mongodb/mongodb/driver/cursor/current.xml
+++ b/reference/mongodb/mongodb/driver/cursor/current.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>public</modifier> <type class="union"><type>array</type><type>object</type></type><methodname>MongoDB\Driver\Cursor::current</methodname>
+   <modifier>public</modifier> <type class="union"><type>array</type><type>object</type><type>null</type></type><methodname>MongoDB\Driver\Cursor::current</methodname>
    <void/>
   </methodsynopsis>
  </refsect1>
@@ -21,7 +21,7 @@
  </refsect1>
 
  <refsect1 role="returnvalues">
-  &reftitle.returnvalues;  
+  &reftitle.returnvalues;
   <para>
    Returns the current result document as an array or object, depending on the
    cursor&apos;s type map. If iteration has not started or the current position
@@ -54,4 +54,4 @@ End:
 vim600: syn=xml fen fdm=syntax fdl=2 si
 vim: et tw=78 syn=sgml
 vi: ts=1 sw=1
---> 
+-->

--- a/reference/mongodb/mongodb/driver/cursorinterface.xml
+++ b/reference/mongodb/mongodb/driver/cursorinterface.xml
@@ -57,15 +57,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/mongodb/driver/cursorinterface.xml
+++ b/reference/mongodb/mongodb/driver/cursorinterface.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision: 344505 $ --> 
+<!-- $Revision: 344505 $ -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-cursorinterface" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -37,12 +37,39 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
     <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-driver-cursorinterface')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/mongodb/driver/manager/construct.xml
+++ b/reference/mongodb/mongodb/driver/manager/construct.xml
@@ -11,9 +11,9 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\Manager::__construct</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>uri</parameter><initializer>"mongodb://127.0.0.1/"</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>uriOptions</parameter><initializer>array()</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>driverOptions</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>uri</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>uriOptions</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>driverOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Constructs a new <classname>MongoDB\Driver\Manager</classname> object with the specified options.
@@ -828,7 +828,7 @@ mongodb://[username:password@]host1[:port1][,host2[:port2],...[,hostN[:portN]]][
                  <note>
                   <simpara>
                    Supplying an <literal>encryptedFieldsMap</literal> provides
-                   more security than relying on an encrypted fields 
+                   more security than relying on an encrypted fields
                    <literal>encryptedFields</literal> obtained from the server.
                    It protects against a malicious server advertising a false
                    <literal>encryptedFields</literal>.

--- a/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/manager/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-manager.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteResult</type><methodname>MongoDB\Driver\Manager::executeBulkWrite</methodname>
    <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\BulkWrite</type><parameter>bulk</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>MongoDB\Driver\WriteConcern</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Executes one or more write operations on the primary server.

--- a/reference/mongodb/mongodb/driver/manager/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-manager.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Manager::executeCommand</methodname>
    <methodparam><type>string</type><parameter>db</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Selects a server according to the <literal>"readPreference"</literal> option

--- a/reference/mongodb/mongodb/driver/manager/executequery.xml
+++ b/reference/mongodb/mongodb/driver/manager/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-manager.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Manager::executeQuery</methodname>
    <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\Query</type><parameter>query</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Selects a server according to the <literal>"readPreference"</literal> option

--- a/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadcommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-manager.executereadcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Manager::executeReadCommand</methodname>
    <methodparam><type>string</type><parameter>db</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Selects a server according to the <literal>"readPreference"</literal> option

--- a/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executereadwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-manager.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Manager::executeReadWriteCommand</methodname>
    <methodparam><type>string</type><parameter>db</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Executes the command on the primary server.

--- a/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/manager/executewritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-manager.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Manager::executeWriteCommand</methodname>
    <methodparam><type>string</type><parameter>db</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Executes the command on the primary server.

--- a/reference/mongodb/mongodb/driver/manager/startsession.xml
+++ b/reference/mongodb/mongodb/driver/manager/startsession.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Session</type><methodname>MongoDB\Driver\Manager::startSession</methodname>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Creates a <classname>MongoDB\Driver\Session</classname> for the given

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/geterror.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/geterror.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>Throwable</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getError</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>Exception</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getError</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/geterror.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandfailedevent/geterror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-monitoring-commandfailedevent.geterror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>Exception</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getError</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>Throwable</type><methodname>MongoDB\Driver\Monitoring\CommandFailedEvent::getError</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
@@ -57,15 +57,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/commandsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-monitoring-commandsubscriber" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -45,6 +45,32 @@
 
   </section>
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
  </partintro>
 
    &reference.mongodb.mongodb.driver.monitoring.entities.commandsubscriber;

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-driver-monitoring-sdamsubscriber" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -47,6 +47,32 @@
 
   </section>
 
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.15.0</entry>
+        <entry>
+         Return types for methods are declared as tentative on PHP 8.0 and newer,
+         triggering deprecation notices in code that implements this interface
+         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
+         attribute can be added to silence the deprecation notice.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
+  </section>
  </partintro>
 
    &reference.mongodb.mongodb.driver.monitoring.entities.sdamsubscriber;

--- a/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/sdamsubscriber.xml
@@ -59,15 +59,7 @@
        </row>
       </thead>
       <tbody>
-       <row>
-        <entry>PECL mongodb 1.15.0</entry>
-        <entry>
-         Return types for methods are declared as tentative on PHP 8.0 and newer,
-         triggering deprecation notices in code that implements this interface
-         without declaring the appropriate return types. The <code>#[ReturnTypeWillChange]</code>
-         attribute can be added to silence the deprecation notice.
-        </entry>
-       </row>
+       &mongodb.changelog.tentative-return-types;
       </tbody>
      </tgroup>
     </informaltable>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/geterror.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/geterror.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>Throwable</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent::getError</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>Exception</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent::getError</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/geterror.xml
+++ b/reference/mongodb/mongodb/driver/monitoring/serverheartbeatfailedevent/geterror.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-monitoring-serverheartbeatfailedevent.geterror" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>Exception</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent::getError</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>Throwable</type><methodname>MongoDB\Driver\Monitoring\ServerHeartbeatFailedEvent::getError</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/query/construct.xml
+++ b/reference/mongodb/mongodb/driver/query/construct.xml
@@ -12,7 +12,7 @@
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\Query::__construct</methodname>
    <methodparam><type class="union"><type>array</type><type>object</type></type><parameter>filter</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>queryOptions</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>queryOptions</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Constructs a new <classname>MongoDB\Driver\Query</classname>, which is an

--- a/reference/mongodb/mongodb/driver/readconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/construct.xml
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ReadConcern::__construct</methodname>
-   <methodparam choice="opt"><type>string</type><parameter>level</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>string</type><type>null</type></type><parameter>level</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Constructs a new <classname>MongoDB\Driver\ReadConcern</classname>, which is

--- a/reference/mongodb/mongodb/driver/readpreference/construct.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/construct.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-readpreference.construct" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -12,8 +12,8 @@
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ReadPreference::__construct</methodname>
    <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>mode</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>tagSets</parameter><initializer>&null;</initializer></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>tagSets</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Constructs a new <classname>MongoDB\Driver\ReadPreference</classname>, which

--- a/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
+++ b/reference/mongodb/mongodb/driver/server/executebulkwrite.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-server.executebulkwrite" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\WriteResult</type><methodname>MongoDB\Driver\Server::executeBulkWrite</methodname>
    <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\BulkWrite</type><parameter>bulk</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>MongoDB\Driver\WriteConcern</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Executes one or more write operations on this server.

--- a/reference/mongodb/mongodb/driver/server/executecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-server.executecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Server::executeCommand</methodname>
    <methodparam><type>string</type><parameter>db</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Executes the command on this server.

--- a/reference/mongodb/mongodb/driver/server/executequery.xml
+++ b/reference/mongodb/mongodb/driver/server/executequery.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-server.executequery" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Server::executeQuery</methodname>
    <methodparam><type>string</type><parameter>namespace</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\Query</type><parameter>query</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>MongoDB\Driver\ReadPreference</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Executes the query on this server.

--- a/reference/mongodb/mongodb/driver/server/executereadcommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadcommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-server.executereadcommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Server::executeReadCommand</methodname>
    <methodparam><type>string</type><parameter>db</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Executes the command on this server.

--- a/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executereadwritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-server.executereadwritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Server::executeReadWriteCommand</methodname>
    <methodparam><type>string</type><parameter>db</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Executes the command on this server.

--- a/reference/mongodb/mongodb/driver/server/executewritecommand.xml
+++ b/reference/mongodb/mongodb/driver/server/executewritecommand.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-server.executewritecommand" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -13,7 +13,7 @@
    <modifier>final</modifier> <modifier>public</modifier> <type>MongoDB\Driver\Cursor</type><methodname>MongoDB\Driver\Server::executeWriteCommand</methodname>
    <methodparam><type>string</type><parameter>db</parameter></methodparam>
    <methodparam><type>MongoDB\Driver\Command</type><parameter>command</parameter></methodparam>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter><initializer>array()</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Executes the command on this server.

--- a/reference/mongodb/mongodb/driver/serverapi/construct.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/construct.xml
@@ -12,8 +12,8 @@
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\ServerApi::__construct</methodname>
    <methodparam><type>string</type><parameter>version</parameter></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>strict</parameter><initializer>&null;</initializer></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>deprecationErrors</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>strict</parameter><initializer>&null;</initializer></methodparam>
+   <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>deprecationErrors</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
 
   <para>

--- a/reference/mongodb/mongodb/driver/serverdescription/getroundtriptime.xml
+++ b/reference/mongodb/mongodb/driver/serverdescription/getroundtriptime.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-serverdescription.getroundtriptime" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\ServerDescription::getRoundTripTime</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\ServerDescription::getRoundTripTime</methodname>
    <void />
   </methodsynopsis>
   <para>

--- a/reference/mongodb/mongodb/driver/session/starttransaction.xml
+++ b/reference/mongodb/mongodb/driver/session/starttransaction.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <refentry xml:id="mongodb-driver-session.starttransaction" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
@@ -11,7 +11,7 @@
   &reftitle.description;
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <type>void</type><methodname>MongoDB\Driver\Session::startTransaction</methodname>
-   <methodparam choice="opt"><type>array</type><parameter>options</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>array</type><type>null</type></type><parameter>options</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Starts a multi-document transaction associated with the session. At any given

--- a/reference/mongodb/mongodb/driver/writeconcern/construct.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/construct.xml
@@ -12,8 +12,8 @@
   <methodsynopsis>
    <modifier>final</modifier> <modifier>public</modifier> <methodname>MongoDB\Driver\WriteConcern::__construct</methodname>
    <methodparam><type class="union"><type>string</type><type>int</type></type><parameter>w</parameter></methodparam>
-   <methodparam choice="opt"><type>int</type><parameter>wtimeout</parameter></methodparam>
-   <methodparam choice="opt"><type>bool</type><parameter>journal</parameter></methodparam>
+   <methodparam choice="opt"><type class="union"><type>int</type><type>null</type></type><parameter>wtimeout</parameter><initializer>&null;</initializer></methodparam>
+  <methodparam choice="opt"><type class="union"><type>bool</type><type>null</type></type><parameter>journal</parameter><initializer>&null;</initializer></methodparam>
   </methodsynopsis>
   <para>
    Constructs a new <classname>MongoDB\Driver\WriteConcern</classname>, which is

--- a/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\WriteConcern::getWtimeout</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type>int</type><methodname>MongoDB\Driver\WriteConcern::getWtimeout</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
@@ -50,7 +50,8 @@
        <entry>PECL mongodb 1.7.0</entry>
        <entry>
         On 32-bit systems, this method will always truncate the <literal>wTimeout</literal>
-        value if it exceeds the 32-bit range.
+        value if it exceeds the 32-bit range. In that case, a warning will be
+        emitted.
        </entry>
       </row>
      </tbody>

--- a/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/getwtimeout.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>MongoDB\BSON\Int64</type></type><methodname>MongoDB\Driver\WriteConcern::getWtimeout</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <type class="union"><type>int</type><type>null</type></type><methodname>MongoDB\Driver\WriteConcern::getWtimeout</methodname>
    <void />
   </methodsynopsis>
  </refsect1>
@@ -49,10 +49,8 @@
       <row>
        <entry>PECL mongodb 1.7.0</entry>
        <entry>
-        On 32-bit systems, this method will return a <classname>MongoDB\BSON\Int64</classname>
-        instance if the WriteConcern object was created with a <literal>wTimeout</literal>
-        that exceeds the 32-bit range. On 64-bit systems, this method will
-        always return an integer value.
+        On 32-bit systems, this method will always truncate the <literal>wTimeout</literal>
+        value if it exceeds the 32-bit range.
        </entry>
       </row>
      </tbody>

--- a/reference/mongodb/tutorial/apm.xml
+++ b/reference/mongodb/tutorial/apm.xml
@@ -41,15 +41,15 @@
 
 class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
 {
-    public function commandStarted( \MongoDB\Driver\Monitoring\CommandStartedEvent $event )
+    public function commandStarted( \MongoDB\Driver\Monitoring\CommandStartedEvent $event ): void
     {
     }
 
-    public function commandSucceeded( \MongoDB\Driver\Monitoring\CommandSucceededEvent $event )
+    public function commandSucceeded( \MongoDB\Driver\Monitoring\CommandSucceededEvent $event ): void
     {
     }
 
-    public function commandFailed( \MongoDB\Driver\Monitoring\CommandFailedEvent $event )
+    public function commandFailed( \MongoDB\Driver\Monitoring\CommandFailedEvent $event ): void
     {
     }
 }
@@ -123,7 +123,7 @@ class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
         return json_encode( array_keys( $filter ) );
     }
 
-    public function commandStarted( \MongoDB\Driver\Monitoring\CommandStartedEvent $event )
+    public function commandStarted( \MongoDB\Driver\Monitoring\CommandStartedEvent $event ): void
     {
         if ( array_key_exists( 'find', (array) $event->getCommand() ) )
         {
@@ -132,7 +132,7 @@ class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
         }
     }
 
-    public function commandSucceeded( \MongoDB\Driver\Monitoring\CommandSucceededEvent $event )
+    public function commandSucceeded( \MongoDB\Driver\Monitoring\CommandSucceededEvent $event ): void
     {
         $requestId = $event->getRequestId();
         if ( array_key_exists( $requestId, $this->pendingCommands ) )
@@ -143,7 +143,7 @@ class QueryTimeCollector implements \MongoDB\Driver\Monitoring\CommandSubscriber
         }
     }
 
-    public function commandFailed( \MongoDB\Driver\Monitoring\CommandFailedEvent $event )
+    public function commandFailed( \MongoDB\Driver\Monitoring\CommandFailedEvent $event ): void
     {
         if ( array_key_exists( $event->getRequestId(), $this->pendingCommands ) )
         {


### PR DESCRIPTION
@jmikola: these are the changes for PHPC-1710. Putting them up for review here to then push the commit to the base repository directly.

This PR includes changes to the method signatures where we discovered nullable option arguments, as well as a changelog entry where we added tentative return types. Changelog entries were omitted for:
* methods where we merely fixed the docs to correspond to reality,
* and final methods where we added return types and enforce parameter types.

I can add more changelog entries if you deem them necessary, but figured they would just cause a huge amount of diff for little to no advantage.

NB: whitespace changes (typically trailing whitespace) were done automatically due to IDE settings and I didn't bother removing them from the diff. LMK if that's ok.