### PR TITLE
Update documentation for Serializable::bsonSerialize

### DIFF
--- a/reference/mongodb/bson/document.xml
+++ b/reference/mongodb/bson/document.xml
@@ -33,6 +33,10 @@
      </ooclass>
 
      <oointerface>
+      <interfacename>MongoDB\BSON\Type</interfacename>
+     </oointerface>
+
+     <oointerface>
       <interfacename>IteratorAggregate</interfacename>
      </oointerface>
 
@@ -47,6 +51,30 @@
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.17.0</entry>
+        <entry>
+         Implements <interfacename>MongoDB\BSON\Type</interfacename>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/packedarray.xml
+++ b/reference/mongodb/bson/packedarray.xml
@@ -33,6 +33,10 @@
      </ooclass>
 
      <oointerface>
+      <interfacename>MongoDB\BSON\Type</interfacename>
+     </oointerface>
+
+     <oointerface>
       <interfacename>IteratorAggregate</interfacename>
      </oointerface>
 
@@ -47,6 +51,30 @@
    </classsynopsis>
 <!-- }}} -->
 
+  </section>
+
+  <section role="changelog">
+   &reftitle.changelog;
+   <para>
+    <informaltable>
+     <tgroup cols="2">
+      <thead>
+       <row>
+        <entry>&Version;</entry>
+        <entry>&Description;</entry>
+       </row>
+      </thead>
+      <tbody>
+       <row>
+        <entry>PECL mongodb 1.17.0</entry>
+        <entry>
+         Implements <interfacename>MongoDB\BSON\Type</interfacename>.
+        </entry>
+       </row>
+      </tbody>
+     </tgroup>
+    </informaltable>
+   </para>
   </section>
 
  </partintro>

--- a/reference/mongodb/bson/persistable.xml
+++ b/reference/mongodb/bson/persistable.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- $Revision$ --> 
+<!-- $Revision$ -->
 
 <phpdoc:classref xml:id="class.mongodb-bson-persistable" xmlns:phpdoc="http://php.net/ns/phpdoc" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xi="http://www.w3.org/2001/XInclude">
 
@@ -47,7 +47,7 @@
      <ooclass>
       <classname>MongoDB\BSON\Persistable</classname>
      </ooclass>
-     
+
      <oointerface>
       <interfacename>MongoDB\BSON\Unserializable</interfacename>
      </oointerface>
@@ -57,9 +57,11 @@
      </oointerface>
     </classsynopsisinfo>
 <!-- }}} -->
-    
+
+    <classsynopsisinfo role="comment">&Methods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-persistable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
+
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
-    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-unserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/mongodb/bson/persistable.xml
+++ b/reference/mongodb/bson/persistable.xml
@@ -62,6 +62,7 @@
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-persistable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
 
     <classsynopsisinfo role="comment">&InheritedMethods;</classsynopsisinfo>
+    <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-serializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
     <xi:include xpointer="xmlns(db=http://docbook.org/ns/docbook) xpointer(id('class.mongodb-bson-unserializable')/db:refentry/db:refsect1[@role='description']/descendant::db:methodsynopsis[not(@role='procedural')])" />
    </classsynopsis>
 <!-- }}} -->

--- a/reference/mongodb/bson/persistable/bsonserialize.xml
+++ b/reference/mongodb/bson/persistable/bsonserialize.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- $Revision$ -->
 
-<refentry xml:id="mongodb-bson-serializable.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
+<refentry xml:id="mongodb-bson-persistable.bsonserialize" xmlns="http://docbook.org/ns/docbook" xmlns:xlink="http://www.w3.org/1999/xlink">
  <refnamediv>
-  <refname>MongoDB\BSON\Serializable::bsonSerialize</refname>
+  <refname>MongoDB\BSON\Persistable::bsonSerialize</refname>
   <refpurpose>Provides an array or document to serialize as BSON</refpurpose>
  </refnamediv>
 
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>array</type><classname>stdClass</classname><classname>MongoDB\BSON\Document</classname><classname>MongoDB\BSON\PackedArray</classname></type><methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>array</type><classname>stdClass</classname><classname>MongoDB\BSON\Document</classname></type><methodname>MongoDB\BSON\Persistable::bsonSerialize</methodname>
    <void />
   </methodsynopsis>
   <para>
    Called during serialization of the object to BSON. The method must return an
-   <type>array</type>, <classname>stdClass</classname>, <classname>MongoDB\BSON\Document</classname>,
-   or <classname>MongoDB\BSON\PackedArray</classname>.
+   <type>array</type>, <classname>stdClass</classname>, or
+   <classname>MongoDB\BSON\Document</classname>.
   </para>
   <para>
    Root documents (e.g. a
-   <interfacename>MongoDB\BSON\Serializable</interfacename> passed to
+   <interfacename>MongoDB\BSON\Persistable</interfacename> passed to
    <function>MongoDB\BSON\fromPHP</function>) will always be serialized as a
    BSON document. For field values, associative arrays and
    <classname>stdClass</classname> instances will be serialized as a BSON
@@ -45,9 +45,8 @@
  <refsect1 role="returnvalues">
   &reftitle.returnvalues;
   <para>
-   An <type>array</type>, <classname>stdClass</classname>, <classname>MongoDB\BSON\Document</classname>,
-   or <classname>MongoDB\BSON\PackedArray</classname> to be serialized as a BSON
-   array or document.
+   An <type>array</type>, <classname>stdClass</classname>, or <classname>MongoDB\BSON\Document</classname>
+   to be serialized as a BSON array or document.
   </para>
  </refsect1>
 
@@ -67,19 +66,8 @@
        <entry>PECL mongodb 1.17.0</entry>
        <entry>
         <para>
-         The return type was changed from <type class="union"><type>array</type><type>object</type></type>.
-         Instead of <type>object</type>, the return type now specifies <classname>stdClass</classname>.
-         Classes that implement this interface must be changed to no longer
-         declare an <type>object</type> return type. As the return type is
-         tentative, a deprecation warning is emitted on PHP 8.1 and newer.
-        </para>
-        <para>
-         In addition to the changes above, the driver now also supports
-         returning instances of <classname>MongoDB\BSON\Document</classname>
-         and <classname>MongoDB\BSON\PackedArray</classname>. Please note that
-         any <classname>MongoDB\BSON\PackedArray</classname> instances returned
-         are silently converted to objects when stored as root documents. They
-         are stored as arrays when used as an embedded field value.
+         This method may now also return <classname>MongoDB\BSON\Document</classname>
+         instances in addition to <type>array</type> and <classname>stdClass</classname>.
         </para>
        </entry>
       </row>
@@ -93,12 +81,12 @@
  <refsect1 role="examples">
   &reftitle.examples;
   <example>
-   <title><function>MongoDB\BSON\Serializable::bsonSerialize</function> returning an associative array for root document</title>
+   <title><function>MongoDB\BSON\Persistable::bsonSerialize</function> returning an associative array for root document</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 
-class MyDocument implements MongoDB\BSON\Serializable
+class MyDocument implements MongoDB\BSON\Persistable
 {
     private $id;
 
@@ -128,12 +116,12 @@ echo MongoDB\BSON\toJSON($bson), "\n";
   </example>
 
   <example>
-   <title><function>MongoDB\BSON\Serializable::bsonSerialize</function> returning a sequential array for root document</title>
+   <title><function>MongoDB\BSON\Persistable::bsonSerialize</function> returning a sequential array for root document</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 
-class MyArray implements MongoDB\BSON\Serializable
+class MyArray implements MongoDB\BSON\Persistable
 {
     function bsonSerialize(): array
     {
@@ -156,12 +144,12 @@ echo MongoDB\BSON\toJSON($bson), "\n";
   </example>
 
   <example>
-   <title><function>MongoDB\BSON\Serializable::bsonSerialize</function> returning an associative array for document field</title>
+   <title><function>MongoDB\BSON\Persistable::bsonSerialize</function> returning an associative array for document field</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 
-class MyDocument implements MongoDB\BSON\Serializable
+class MyDocument implements MongoDB\BSON\Persistable
 {
     function bsonSerialize(): array
     {
@@ -185,12 +173,12 @@ echo MongoDB\BSON\toJSON($bson), "\n";
   </example>
 
   <example>
-   <title><function>MongoDB\BSON\Serializable::bsonSerialize</function> returning a sequential array for document field</title>
+   <title><function>MongoDB\BSON\Persistable::bsonSerialize</function> returning a sequential array for document field</title>
    <programlisting role="php">
 <![CDATA[
 <?php
 
-class MyArray implements MongoDB\BSON\Serializable
+class MyArray implements MongoDB\BSON\Persistable
 {
     function bsonSerialize(): array
     {
@@ -218,7 +206,7 @@ echo MongoDB\BSON\toJSON($bson), "\n";
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><function>MongoDB\BSON\Unserializable::bsonUnserialize</function></member>
+   <member><function>MongoDB\BSON\Unpersistable::bsonUnserialize</function></member>
    <member><interfacename>MongoDB\BSON\Persistable</interfacename></member>
    <member><xref linkend="mongodb.persistence"/></member>
   </simplelist>

--- a/reference/mongodb/bson/persistable/bsonserialize.xml
+++ b/reference/mongodb/bson/persistable/bsonserialize.xml
@@ -19,13 +19,10 @@
    <classname>MongoDB\BSON\Document</classname>.
   </para>
   <para>
-   Root documents (e.g. a
-   <interfacename>MongoDB\BSON\Persistable</interfacename> passed to
-   <function>MongoDB\BSON\fromPHP</function>) will always be serialized as a
-   BSON document. For field values, associative arrays and
-   <classname>stdClass</classname> instances will be serialized as a BSON
-   document and sequential arrays (i.e. sequential, numeric indexes starting at
-   <literal>0</literal>) will be serialized as a BSON array.
+   The return value will always be serialized as a BSON document. The serialized
+   document will include a field containing the class name of the object. For
+   this reason, it is not possible to return a <classname>MongoDB\BSON\PackedArray</classname>
+   instance in this method.
   </para>
   <para>
    Users are encouraged to include an <property>_id</property> property (e.g. a
@@ -46,7 +43,7 @@
   &reftitle.returnvalues;
   <para>
    An <type>array</type>, <classname>stdClass</classname>, or <classname>MongoDB\BSON\Document</classname>
-   to be serialized as a BSON array or document.
+   to be serialized as a BSON document.
   </para>
  </refsect1>
 
@@ -77,136 +74,11 @@
   </para>
  </refsect1>
 
-
- <refsect1 role="examples">
-  &reftitle.examples;
-  <example>
-   <title><function>MongoDB\BSON\Persistable::bsonSerialize</function> returning an associative array for root document</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-class MyDocument implements MongoDB\BSON\Persistable
-{
-    private $id;
-
-    function __construct()
-    {
-        $this->id = new MongoDB\BSON\ObjectId;
-    }
-
-    function bsonSerialize(): array
-    {
-        return ['_id' => $this->id, 'foo' => 'bar'];
-    }
-}
-
-$bson = MongoDB\BSON\fromPHP(new MyDocument);
-echo MongoDB\BSON\toJSON($bson), "\n";
-
-?>
-]]>
-   </programlisting>
-   &example.outputs.similar;
-   <screen>
-<![CDATA[
-{ "_id" : { "$oid" : "56cccdcada14d8755a58c591" }, "foo" : "bar" }
-]]>
-   </screen>
-  </example>
-
-  <example>
-   <title><function>MongoDB\BSON\Persistable::bsonSerialize</function> returning a sequential array for root document</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-class MyArray implements MongoDB\BSON\Persistable
-{
-    function bsonSerialize(): array
-    {
-        return [1, 2, 3];
-    }
-}
-
-$bson = MongoDB\BSON\fromPHP(new MyArray);
-echo MongoDB\BSON\toJSON($bson), "\n";
-
-?>
-]]>
-   </programlisting>
-   &example.outputs;
-   <screen>
-<![CDATA[
-{ "0" : 1, "1" : 2, "2" : 3 }
-]]>
-   </screen>
-  </example>
-
-  <example>
-   <title><function>MongoDB\BSON\Persistable::bsonSerialize</function> returning an associative array for document field</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-class MyDocument implements MongoDB\BSON\Persistable
-{
-    function bsonSerialize(): array
-    {
-        return ['foo' => 'bar'];
-    }
-}
-
-$value = ['document' => new MyDocument];
-$bson = MongoDB\BSON\fromPHP($value);
-echo MongoDB\BSON\toJSON($bson), "\n";
-
-?>
-]]>
-   </programlisting>
-   &example.outputs;
-   <screen>
-<![CDATA[
-{ "document" : { "foo" : "bar" } }
-]]>
-   </screen>
-  </example>
-
-  <example>
-   <title><function>MongoDB\BSON\Persistable::bsonSerialize</function> returning a sequential array for document field</title>
-   <programlisting role="php">
-<![CDATA[
-<?php
-
-class MyArray implements MongoDB\BSON\Persistable
-{
-    function bsonSerialize(): array
-    {
-        return [1, 2, 3];
-    }
-}
-
-$value = ['array' => new MyArray];
-$bson = MongoDB\BSON\fromPHP($value);
-echo MongoDB\BSON\toJSON($bson), "\n";
-
-?>
-]]>
-   </programlisting>
-   &example.outputs;
-   <screen>
-<![CDATA[
-{ "array" : [ 1, 2, 3 ] }
-]]>
-   </screen>
-  </example>
- </refsect1>
-
-
  <refsect1 role="seealso">
   &reftitle.seealso;
   <simplelist>
-   <member><function>MongoDB\BSON\Unpersistable::bsonUnserialize</function></member>
+   <member><function>MongoDB\BSON\Serializable::bsonSerialize</function></member>
+   <member><function>MongoDB\BSON\Unserializable::bsonUnserialize</function></member>
    <member><interfacename>MongoDB\BSON\Persistable</interfacename></member>
    <member><xref linkend="mongodb.persistence"/></member>
   </simplelist>

--- a/reference/mongodb/bson/serializable/bsonserialize.xml
+++ b/reference/mongodb/bson/serializable/bsonserialize.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>array</type><type>object</type></type><methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>
+   <modifier>abstract</modifier> <modifier>public</modifier> <type class="union"><type>array</type><classname>stdClass</classname></type><methodname>MongoDB\BSON\Serializable::bsonSerialize</methodname>
    <void />
   </methodsynopsis>
   <para>
@@ -46,6 +46,34 @@
   <para>
    An <type>array</type> or <classname>stdClass</classname> to be serialized as
    a BSON array or document.
+  </para>
+ </refsect1>
+
+ <refsect1 role="changelog">
+  &reftitle.changelog;
+  <para>
+   <informaltable>
+    <tgroup cols="2">
+     <thead>
+      <row>
+       <entry>&Version;</entry>
+       <entry>&Description;</entry>
+      </row>
+     </thead>
+     <tbody>
+      <row>
+       <entry>PECL mongodb 1.17.0</entry>
+       <entry>
+        <para>
+         The return type was changed to only allow an <type>array</type> or <classname>stdClass</classname>
+         value to be returned. As the return type is tentative, this will only
+         emit a deprecation warning on PHP 8.1 and newer.
+        </para>
+       </entry>
+      </row>
+     </tbody>
+    </tgroup>
+   </informaltable>
   </para>
  </refsect1>
 

--- a/reference/mongodb/mongodb/driver/readconcern/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readconcern/bsonserialize.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ReadConcern::bsonSerialize</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <classname>stdClass</classname><methodname>MongoDB\Driver\ReadConcern::bsonSerialize</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/readpreference/bsonserialize.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ReadPreference::bsonSerialize</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <classname>stdClass</classname><methodname>MongoDB\Driver\ReadPreference::bsonSerialize</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/serverapi/bsonserialize.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\ServerApi::bsonSerialize</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <classname>stdClass</classname><methodname>MongoDB\Driver\ServerApi::bsonSerialize</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/mongodb/driver/writeconcern/bsonserialize.xml
+++ b/reference/mongodb/mongodb/driver/writeconcern/bsonserialize.xml
@@ -10,7 +10,7 @@
  <refsect1 role="description">
   &reftitle.description;
   <methodsynopsis>
-   <modifier>final</modifier> <modifier>public</modifier> <type>object</type><methodname>MongoDB\Driver\WriteConcern::bsonSerialize</methodname>
+   <modifier>final</modifier> <modifier>public</modifier> <classname>stdClass</classname><methodname>MongoDB\Driver\WriteConcern::bsonSerialize</methodname>
    <void />
   </methodsynopsis>
  </refsect1>

--- a/reference/mongodb/versions.xml
+++ b/reference/mongodb/versions.xml
@@ -319,6 +319,7 @@
 
  <!-- BSON interfaces -->
  <function name='mongodb\bson\persistable' from='mongodb &gt;=1.0.0'/>
+ <function name='mongodb\bson\persistable::bsonserialize' from='mongodb &gt;=1.0.0'/>
 
  <function name='mongodb\bson\serializable' from='mongodb &gt;=1.0.0'/>
  <function name='mongodb\bson\serializable::bsonserialize' from='mongodb &gt;=1.0.0'/>


### PR DESCRIPTION
Ping @jmikola.

* Document `Document` and `PackedArray` implementing `Type`
* Document `Serializable::bsonSerialize` return type changing to `array|stdClass|Document|PackedArray`
* Document `Persistable::bsonSerialize` return type changing to `array|stdClass|Document`
* Document `bsonSerialize` method in `ReadConcern`, `ReadPreference`, `ServerApi`, and `WriteConcern` returning `stdClass`